### PR TITLE
Update .kjspkg on 1.19+ branch to match versions

### DIFF
--- a/.kjspkg
+++ b/.kjspkg
@@ -1,8 +1,8 @@
 {
     "author": "TheonlyTazz",
-    "description": "KubeJS Helper Script - a Craft.zs Equivelant",
+    "description": "KubeJS Helper Script - a Craft.zs Equivelant. KJS6 version",
     
-    "versions": [8],
+    "versions": [9, 10],
     "modloaders": ["fabric", "forge"],
     "dependencies": [],
     "incompatibilities": []


### PR DESCRIPTION
Pretty much title. Also added "KJS6 version" to the description to differentiate the packages